### PR TITLE
Add the missing cstdint include to find uint32_t

### DIFF
--- a/stopwordset.cc
+++ b/stopwordset.cc
@@ -11,6 +11,7 @@ extern "C" {
 }
 #include <cstring>
 #include <string>
+#include <cstdint>
 #include <unordered_set>
 
 


### PR DESCRIPTION
Without this, CBL build fails on Fedora 38 
```
$ gcc --version
gcc (GCC) 13.1.1 20230614 (Red Hat 13.1.1-4)
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
``` 
with the error
```
$ cd /var/tmp/couchbase-lite-core/build_cmake/unix
$ make 
[  0%] Built target CouchbaseSqlite3
[ 26%] Built target LiteCoreObjects
[ 28%] Built target BLIPObjects
[ 39%] Built target FleeceObjects
[ 39%] Building CXX object vendor/sqlite3-unicodesn/CMakeFiles/SQLite3_UnicodeSN.dir/stopwordset.cc.o
/var/tmp/couchbase-lite-C/vendor/couchbase-lite-core/vendor/sqlite3-unicodesn/stopwordset.cc:49:9: error: ‘uint32_t’ does not name a type
   49 |         uint32_t operator() (slice const& s) const noexcept {
      |         ^~~~~~~~
/var/tmp/couchbase-lite-C/vendor/couchbase-lite-core/vendor/sqlite3-unicodesn/stopwordset.cc:19:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   18 | #include "stopwords_fr.h"
  +++ |+#include <cstdint>
   19 | 
In file included from /usr/include/c++/13/bits/hashtable.h:35,
                 from /usr/include/c++/13/bits/unordered_set.h:33,
                 from /usr/include/c++/13/unordered_set:41,
                 from /var/tmp/couchbase-lite-C/vendor/couchbase-lite-core/vendor/sqlite3-unicodesn/stopwordset.cc:14:
/usr/include/c++/13/bits/hashtable_policy.h: In instantiation of ‘std::__detail::_Hash_code_base<_Key, _Value, _ExtractKey, _Hash, _RangeHash, _Unused, __cache_hash_code>::__hash_code std::__detail::_Hash_code_base<_Key, _Value, _ExtractKey, _Hash, _RangeHash, _Unused, __cache_hash_code>::_M_hash_code(const _Key&) const [with _Key = stopwordset::slice; _Value = stopwordset::slice; _ExtractKey = std::__detail::_Identity; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; bool __cache_hash_code = true; __hash_code = long unsigned int]’:
/usr/include/c++/13/bits/hashtable.h:1662:46:   required from ‘std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::find(const key_type&) [with _Key = stopwordset::slice; _Value = stopwordset::slice; _Alloc = std::allocator<stopwordset::slice>; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<stopwordset::slice>; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<true, true, true>; iterator = std::__detail::_Insert_base<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::iterator; key_type = stopwordset::slice]’
/usr/include/c++/13/bits/unordered_set.h:658:25:   required from ‘std::unordered_set<_Value, _Hash, _Pred, _Alloc>::iterator std::unordered_set<_Value, _Hash, _Pred, _Alloc>::find(const key_type&) [with _Value = stopwordset::slice; _Hash = stopwordset::sliceHash; _Pred = std::equal_to<stopwordset::slice>; _Alloc = std::allocator<stopwordset::slice>; iterator = std::__detail::_Insert_base<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::iterator; key_type = stopwordset::slice]’
/var/tmp/couchbase-lite-C/vendor/couchbase-lite-core/vendor/sqlite3-unicodesn/stopwordset.cc:80:27:   required from here
/usr/include/c++/13/bits/hashtable_policy.h:1304:23: error: static assertion failed: hash function must be invocable with an argument of key type
 1304 |         static_assert(__is_invocable<const _Hash&, const _Key&>{},
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/13/bits/hashtable_policy.h:1304:23: note: ‘std::__is_invocable<const stopwordset::sliceHash&, const stopwordset::slice&>()’ evaluates to false
/usr/include/c++/13/bits/hashtable_policy.h:1306:25: error: no match for call to ‘(const stopwordset::sliceHash) (const stopwordset::slice&)’
 1306 |         return _M_hash()(__k);
      |                ~~~~~~~~~^~~~~
/usr/include/c++/13/bits/hashtable_policy.h: In instantiation of ‘std::__detail::_Hash_code_base<_Key, _Value, _ExtractKey, _Hash, _RangeHash, _Unused, __cache_hash_code>::__hash_code std::__detail::_Hash_code_base<_Key, _Value, _ExtractKey, _Hash, _RangeHash, _Unused, __cache_hash_code>::_M_hash_code_tr(const _Kt&) const [with _Kt = stopwordset::slice; _Key = stopwordset::slice; _Value = stopwordset::slice; _ExtractKey = std::__detail::_Identity; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; bool __cache_hash_code = true; __hash_code = long unsigned int]’:
/usr/include/c++/13/bits/hashtable.h:2249:44:   required from ‘std::pair<typename std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator, bool> std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::_M_insert_unique(_Kt&&, _Arg&&, const _NodeGenerator&) [with _Kt = stopwordset::slice; _Arg = stopwordset::slice; _NodeGenerator = std::__detail::_AllocNode<std::allocator<std::__detail::_Hash_node<stopwordset::slice, true> > >; _Key = stopwordset::slice; _Value = stopwordset::slice; _Alloc = std::allocator<stopwordset::slice>; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<stopwordset::slice>; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<true, true, true>; typename std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator = std::__detail::_Insert_base<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::iterator; typename _Traits::__constant_iterators = std::__detail::_Hashtable_traits<true, true, true>::__constant_iterators]’
/usr/include/c++/13/bits/hashtable.h:904:27:   required from ‘std::pair<typename std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator, bool> std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::_M_insert_unique_aux(_Arg&&, const _NodeGenerator&) [with _Arg = stopwordset::slice; _NodeGenerator = std::__detail::_AllocNode<std::allocator<std::__detail::_Hash_node<stopwordset::slice, true> > >; _Key = stopwordset::slice; _Value = stopwordset::slice; _Alloc = std::allocator<stopwordset::slice>; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<stopwordset::slice>; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<true, true, true>; typename std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator = std::__detail::_Insert_base<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::iterator; typename _Traits::__constant_iterators = std::__detail::_Hashtable_traits<true, true, true>::__constant_iterators]’
/usr/include/c++/13/bits/hashtable.h:916:31:   required from ‘std::pair<typename std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator, bool> std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::_M_insert(_Arg&&, const _NodeGenerator&, std::true_type) [with _Arg = stopwordset::slice; _NodeGenerator = std::__detail::_AllocNode<std::allocator<std::__detail::_Hash_node<stopwordset::slice, true> > >; _Key = stopwordset::slice; _Value = stopwordset::slice; _Alloc = std::allocator<stopwordset::slice>; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<stopwordset::slice>; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<true, true, true>; typename std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator = std::__detail::_Insert_base<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::iterator; typename _Traits::__constant_iterators = std::__detail::_Hashtable_traits<true, true, true>::__constant_iterators; std::true_type = std::integral_constant<bool, true>]’
/usr/include/c++/13/bits/hashtable_policy.h:1071:22:   required from ‘std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits, true>::__ireturn_type std::__detail::_Insert<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits, true>::insert(value_type&&) [with _Key = stopwordset::slice; _Value = stopwordset::slice; _Alloc = std::allocator<stopwordset::slice>; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<stopwordset::slice>; _Hash = stopwordset::sliceHash; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<true, true, true>; __ireturn_type = std::__detail::_Insert<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true>, true>::__ireturn_type; value_type = stopwordset::slice]’
/usr/include/c++/13/bits/unordered_set.h:433:27:   required from ‘std::pair<typename std::_Hashtable<_Value, _Value, _Alloc, std::__detail::_Identity, _Pred, _Hash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<std::__not_<std::__and_<std::__is_fast_hash<_Hash>, std::__is_nothrow_invocable<const _Hash&, const _Tp&> > >::value, true, true> >::iterator, bool> std::unordered_set<_Value, _Hash, _Pred, _Alloc>::insert(value_type&&) [with _Value = stopwordset::slice; _Hash = stopwordset::sliceHash; _Pred = std::equal_to<stopwordset::slice>; _Alloc = std::allocator<stopwordset::slice>; typename std::_Hashtable<_Value, _Value, _Alloc, std::__detail::_Identity, _Pred, _Hash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<std::__not_<std::__and_<std::__is_fast_hash<_Hash>, std::__is_nothrow_invocable<const _Hash&, const _Tp&> > >::value, true, true> >::iterator = std::__detail::_Insert_base<stopwordset::slice, stopwordset::slice, std::allocator<stopwordset::slice>, std::__detail::_Identity, std::equal_to<stopwordset::slice>, stopwordset::sliceHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::iterator; value_type = stopwordset::slice]’
/var/tmp/couchbase-lite-C/vendor/couchbase-lite-core/vendor/sqlite3-unicodesn/stopwordset.cc:92:30:   required from here
/usr/include/c++/13/bits/hashtable_policy.h:1313:25: error: static assertion failed: hash function must be invocable with an argument of key type
 1313 |           static_assert(__is_invocable<const _Hash&, const _Kt&>{},
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/13/bits/hashtable_policy.h:1313:25: note: ‘std::__is_invocable<const stopwordset::sliceHash&, const stopwordset::slice&>()’ evaluates to false
/usr/include/c++/13/bits/hashtable_policy.h:1315:27: error: no match for call to ‘(const stopwordset::sliceHash) (const stopwordset::slice&)’
 1315 |           return _M_hash()(__k);
      |                  ~~~~~~~~~^~~~~
make[2]: *** [vendor/sqlite3-unicodesn/CMakeFiles/SQLite3_UnicodeSN.dir/build.make:594: vendor/sqlite3-unicodesn/CMakeFiles/SQLite3_UnicodeSN.dir/stopwordset.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:575: vendor/sqlite3-unicodesn/CMakeFiles/SQLite3_UnicodeSN.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```